### PR TITLE
feat: Add bash wrapper for packagetracker.py 

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,42 @@ python packagetracker.py [options] [filename]
     python packagetracker.py --test
     ```
 
+### Using the Bash Wrapper (`packagetracker.sh`)
+
+The `packagetracker.sh` script provides a convenient bash wrapper around the `packagetracker.py` script.
+
+**How to run:**
+
+```bash
+./packagetracker.sh [options] [filename]
+```
+
+**Options:**
+
+The wrapper supports several options to control output format and content, such as `--json`, `--gzip`, and `--detailed`. These options are passed directly to the underlying `packagetracker.py` script. For a full list of options and their descriptions, run:
+
+```bash
+./packagetracker.sh --help
+```
+
+**Arguments:**
+
+*   `filename`: Optional. The name of the output file. If not specified, a timestamped filename will be used by `packagetracker.py`.
+
+**Examples:**
+
+*   Save package list to a JSON file using the wrapper:
+
+    ```bash
+    ./packagetracker.sh --json packages.json
+    ```
+
+*   Run in test mode using the wrapper:
+
+    ```bash
+    ./packagetracker.sh --test
+    ```
+
 ## Dependencies
 
 *   `python3`

--- a/packagetracker.sh
+++ b/packagetracker.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+
+# Function to display help message
+show_help() {
+  cat << EOF
+Usage: ./packagetracker.sh [options] [filename]
+
+Description:
+  A bash wrapper for the packagetracker.py script.
+  This script collects information about installed packages and system metadata.
+
+Options:
+  --help        Show this help message and exit.
+  --json        Save output in JSON format.
+  --gzip        Compress the output file using gzip.
+  --detailed    Include detailed package information (description, dependencies).
+  --test        Run in test mode (prints what would happen without writing files).
+  [filename]    Optional. Specify the output filename.
+                If not provided, a timestamped filename will be generated.
+EOF
+}
+
+# Initialize variables
+PYTHON_ARGS=""
+FILENAME_ARG=""
+
+# Parse command-line arguments
+while [[ "$#" -gt 0 ]]; do
+  case "$1" in
+    --help)
+      show_help
+      exit 0
+      ;;
+    --json)
+      PYTHON_ARGS+=" --json"
+      shift
+      ;;
+    --gzip)
+      PYTHON_ARGS+=" --gzip"
+      shift
+      ;;
+    --detailed)
+      PYTHON_ARGS+=" --detailed"
+      shift
+      ;;
+    --test)
+      PYTHON_ARGS+=" --test"
+      shift
+      ;;
+    -*)
+      echo "Error: Unknown option $1"
+      exit 1
+      ;;
+    *)
+      if [[ -n "$FILENAME_ARG" ]]; then
+        echo "Error: Only one filename can be specified."
+        exit 1
+      fi
+      FILENAME_ARG="$1"
+      shift
+      ;;
+  esac
+done
+
+# Trim leading/trailing whitespace from PYTHON_ARGS
+PYTHON_ARGS=$(echo "$PYTHON_ARGS" | awk '{$1=$1};1')
+
+# Construct and execute the command
+CMD="python3 packagetracker.py $PYTHON_ARGS $FILENAME_ARG"
+echo "Executing: $CMD" # Added for debugging, can be removed later
+eval "$CMD"

--- a/test_wrapper.sh
+++ b/test_wrapper.sh
@@ -1,0 +1,115 @@
+#!/bin/bash
+
+# Ensure packagetracker.sh is executable
+chmod +x ./packagetracker.sh
+
+# Initialize test counters
+total_tests=0
+passed_tests=0
+
+# Helper function to assert command equality
+assert_command_equals() {
+  expected_command="packagetracker.py $1"
+  shift
+  actual_args="$@"
+
+  total_tests=$((total_tests + 1))
+
+  # Mock python3
+  export python3_CMD_ARGS=""
+  python3() {
+    python3_CMD_ARGS="$*"
+  }
+  export -f python3
+
+  # Execute packagetracker.sh
+  # The echo "Executing: $CMD" line in packagetracker.sh will be captured by stdout
+  # We need to suppress it or account for it. For now, let's capture it.
+  # Also, the actual script execution might print errors to stderr.
+  # Let's capture both stdout and stderr.
+  script_output=$(./packagetracker.sh $actual_args 2>&1)
+
+  # The packagetracker.sh script has an "Executing: ..." line.
+  # We need to extract the command that was actually prepared for python3.
+  # This is now stored in python3_CMD_ARGS by our mock.
+  actual_executed_command="$python3_CMD_ARGS"
+
+  # Unset mock
+  unset -f python3
+  unset python3_CMD_ARGS
+
+  echo "Test Case: ./packagetracker.sh $actual_args"
+  echo "Expected for packagetracker.py: '$expected_command'"
+  echo "Actual for packagetracker.py: '$actual_executed_command'"
+
+  # Remove the "Executing: python3 ..." line from the script_output if we were to check script_output directly
+  # For now, we rely on the mocked python3_CMD_ARGS
+
+  if [[ "$actual_executed_command" == "$expected_command" ]]; then
+    echo "PASS"
+    passed_tests=$((passed_tests + 1))
+  else
+    echo "FAIL"
+    echo "  Script output was: $script_output"
+  fi
+  echo "--------------------------------------------------"
+}
+
+# Test cases
+assert_command_equals "--json --test mypackages.json" --json --test mypackages.json
+assert_command_equals "--gzip" --gzip
+assert_command_equals "--detailed output.txt" --detailed output.txt
+assert_command_equals "" # No args for python script
+
+# Test --help
+total_tests=$((total_tests + 1))
+echo "Test Case: ./packagetracker.sh --help"
+help_output=$(./packagetracker.sh --help)
+if echo "$help_output" | grep -q "Usage:"; then
+  echo "PASS"
+  passed_tests=$((passed_tests + 1))
+else
+  echo "FAIL"
+  echo "  Help output was: $help_output"
+fi
+echo "--------------------------------------------------"
+
+# Test unknown option
+total_tests=$((total_tests + 1))
+echo "Test Case: ./packagetracker.sh --unknown"
+./packagetracker.sh --unknown > /dev/null 2>&1
+exit_status=$?
+if [[ $exit_status -eq 1 ]]; then
+  echo "PASS"
+  passed_tests=$((passed_tests + 1))
+else
+  echo "FAIL - Expected exit status 1, got $exit_status"
+fi
+echo "--------------------------------------------------"
+
+# Test multiple filenames
+total_tests=$((total_tests + 1))
+echo "Test Case: ./packagetracker.sh file1 file2"
+./packagetracker.sh file1 file2 > /dev/null 2>&1
+exit_status=$?
+if [[ $exit_status -eq 1 ]]; then
+  echo "PASS"
+  passed_tests=$((passed_tests + 1))
+else
+  echo "FAIL - Expected exit status 1, got $exit_status"
+fi
+echo "--------------------------------------------------"
+
+# Summary
+echo ""
+echo "Test Summary: $passed_tests / $total_tests tests passed."
+
+# Make test_wrapper.sh executable
+chmod +x ./test_wrapper.sh
+
+# Exit with 0 if all tests passed, 1 otherwise
+if [[ $passed_tests -eq $total_tests ]]; then
+  exit 0
+else
+  exit 1
+fi


### PR DESCRIPTION
This commit introduces a bash wrapper script (`packagetracker.sh`) for the `packagetracker.py` utility.

The wrapper provides a convenient command-line interface and supports all the functionalities of the Python script, including:
- Outputting in JSON format (`--json`)
- Compressing output with gzip (`--gzip`)
- Including detailed package information (`--detailed`)
- Running in test mode (`--test`)
- Specifying an output filename

A help function (`--help`) is included in the bash script to display usage instructions and available options.

A test script (`test_wrapper.sh`) has been added to verify the argument parsing and forwarding capabilities of the bash wrapper.

The README.md file has been updated to include instructions on how you can use the new `packagetracker.sh` script.